### PR TITLE
fix(docker): troute.nwm build

### DIFF
--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -507,7 +507,8 @@ RUN if [ "${NGEN_WITH_ROUTING}" == "ON" ]; then \
       && python3 -m build . \
       && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
       && cd ${WORKDIR}/t-route/src/troute-nwm \
-      && python3 setup.py bdist_wheel \
+      # troute-nwm doesn't use setup.py ... use build to make the wheel; see https://github.com/NOAA-OWP/t-route/pull/784 \
+      && python3 -m build . \
       && cp dist/*.whl ${WORKDIR}/t-route/wheels/ ; \
     fi
 


### PR DESCRIPTION
Fix how `troute.nwm` is built. https://github.com/NOAA-OWP/t-route/pull/784 removed `setup.py`, as a result the package should now be built with `build`.

Fixes #673.